### PR TITLE
adapt build system for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,33 +1,38 @@
 val testLibraries = List(
   "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
-  "org.typelevel" %% "discipline" % "0.10.0" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test")
+  "org.typelevel" %% "discipline-core" % "1.0.1" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test")
 
 val catsLibraries = List(
-  "org.typelevel" %% "cats-core" % "1.5.0-RC1")
+  "org.typelevel" %% "cats-core" % "2.0.0")
 
 lazy val commonSettings = List(
-  addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.4"),
+  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
   organization      := "com.alexknvl",
   version           := "0.4.0",
   scalaVersion      := "2.12.1",
-  scalaOrganization := "org.typelevel",
-  crossScalaVersions := Seq("2.11.8"),
+  scalaOrganization := {
+    if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 >= 13))
+      "org.scala-lang"
+    else
+      "org.typelevel"
+  },
+  crossScalaVersions := Seq("2.13.0"),
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
   scalacOptions ++= List(
     "-deprecation", "-unchecked", "-feature",
     "-encoding", "UTF-8",
     "-language:existentials",
     "-language:higherKinds",
-    "-language:implicitConversions",
-    "-Yno-adapted-args", "-Ywarn-dead-code",
-    "-Yliteral-types",
-    "-Ywarn-numeric-widen", "-Xfuture"),
+    "-language:implicitConversions") ++ {
+    if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 13))
+      List("-Yno-adapted-args", "-Ywarn-dead-code", "-Yliteral-types", "-Ywarn-numeric-widen", "-Xfuture")
+    else Nil
+  },
   resolvers ++= List(
     Resolver.sonatypeRepo("snapshots"),
     Resolver.sonatypeRepo("releases")),
-  libraryDependencies ++= testLibraries,
-  wartremoverWarnings ++= Warts.all
+  libraryDependencies ++= testLibraries
 )
 
 lazy val root = (project in file("."))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=1.3.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 //addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.3")
-//addSbtPlugin("me.lessis" % "bintray-sbt" % "0.5.5")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.1.1")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+//addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.3")
+//addSbtPlugin("me.lessis" % "bintray-sbt" % "0.5.5")


### PR DESCRIPTION
Hey,

With these changes it's possible to publish the library for both 2.12 and 2.13. I've removed Scala 2.11 because I couldn't make all three versions work with the same build definition, but 2.11 is obsolete at this point so I hope it's OK.
